### PR TITLE
Refactoring EncryptedSharedPrefUtil.kt to implement an interface 

### DIFF
--- a/vivy_encryptor/src/androidTest/java/com/vivy/localEncryption/SharedPrefEncryptionTest.kt
+++ b/vivy_encryptor/src/androidTest/java/com/vivy/localEncryption/SharedPrefEncryptionTest.kt
@@ -105,4 +105,47 @@ class SharedPrefEncryptionTest {
 
          assertFalse(encryptedSharedPrefUtil.get(key).blockingGet().isPresent)
     }
+
+
+    @Test fun testGetForNonExistentValuePassingId() {
+
+        encryptedSharedPrefUtil = EncryptedSharedPrefUtil(sharedPreferences, generateRandomTestKey(), userIdentifier)
+
+        val option = encryptedSharedPrefUtil.get("KEY_TEST_FOR_KEY_THAT_DOESN_T_EXIST",userIdentifier.getId()).blockingGet()
+
+        assertFalse(option.isPresent)
+    }
+
+    @Test fun testUpdateExistingValuePassingId() {
+
+        encryptedSharedPrefUtil = EncryptedSharedPrefUtil(sharedPreferences, generateRandomTestKey(), userIdentifier)
+
+        val expectedResult = "expected test result!"
+
+        encryptedSharedPrefUtil.update("KEY_TEST_FOR_KEY_THAT_EXISTS", expectedResult).blockingFirst()
+
+        val option = encryptedSharedPrefUtil.get("KEY_TEST_FOR_KEY_THAT_EXISTS",userIdentifier.getId()).blockingGet()
+
+        assertTrue(option.isPresent)
+        assertEquals(expectedResult, option.get())
+    }
+
+    @Test fun testDeleteExistingValuePassingId() {
+
+        encryptedSharedPrefUtil = EncryptedSharedPrefUtil(sharedPreferences, generateRandomTestKey(), userIdentifier)
+
+        val expectedResult = "expected test result!"
+        val key="KEY_TEST_FOR_KEY_THAT_EXISTS"
+        encryptedSharedPrefUtil.update(key, expectedResult,userIdentifier.getId()).blockingFirst()
+
+        val option = encryptedSharedPrefUtil.get(key).blockingGet()
+
+        assertTrue(option.isPresent)
+        assertEquals(expectedResult, option.get())
+
+        encryptedSharedPrefUtil.delete(key,userIdentifier.getId()).blockingGet()
+
+        assertFalse(encryptedSharedPrefUtil.get(key).blockingGet().isPresent)
+    }
+
 }

--- a/vivy_encryptor/src/main/java/com/vivy/localEncryption/EncryptedSharedPrefUtil.kt
+++ b/vivy_encryptor/src/main/java/com/vivy/localEncryption/EncryptedSharedPrefUtil.kt
@@ -94,7 +94,7 @@ open class EncryptedSharedPrefUtil(
     override fun get(key: String): Single<Optional<String>> {
         return get(key, userIdentifier.getId())
     }
-    
+
 
     fun decrypt(encryptedText: String): Single<Optional<String>> {
         return Single.just(encryptedText)

--- a/vivy_encryptor/src/main/java/com/vivy/localEncryption/EncryptedSharedPreferences.kt
+++ b/vivy_encryptor/src/main/java/com/vivy/localEncryption/EncryptedSharedPreferences.kt
@@ -1,0 +1,44 @@
+package com.vivy.localEncryption
+
+import com.google.common.base.Optional
+import io.reactivex.Completable
+import io.reactivex.Observable
+import io.reactivex.Single
+import polanski.option.Option
+
+interface EncryptedSharedPreferences {
+    fun update(
+        key: String,
+        value: String,
+        user: String
+    ): Observable<String>
+
+    fun update(
+        key: String,
+        value: String
+    ): Observable<String>
+
+    fun delete(
+        key: String,
+        user: String
+    ): Completable
+
+    fun delete(
+        key: String
+    ): Completable
+
+    fun get(
+        key: String,
+        user: String
+    ): Single<Optional<String>>
+
+    fun get(
+        key: String
+    ): Single<Optional<String>>
+
+
+    fun <J> get(
+        key: String,
+        clazz: Class<J>
+    ): Single<Option<J>>
+}


### PR DESCRIPTION
Added an interface EncryptedSharedPreferences to integrate this library with the PKI module, please notice that new versions of `delete`,`update` and `get` were added to allow the use of these operations without explicitly passing the user ID. The reason they were added is because we can't user default values with function overriding an interface. 