### PR TITLE
[#SEC-473] Android Import | Decrypt the encrypted key

### DIFF
--- a/vivy_encryptor/src/main/java/com/vivy/support/KeyConverter.kt
+++ b/vivy_encryptor/src/main/java/com/vivy/support/KeyConverter.kt
@@ -1,12 +1,18 @@
 package com.vivy.support
 
+import org.bouncycastle.asn1.pkcs.EncryptedPrivateKeyInfo
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo
 import org.bouncycastle.openssl.PEMKeyPair
 import org.bouncycastle.openssl.PEMParser
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter
 import org.bouncycastle.util.io.pem.PemObject
 import org.bouncycastle.util.io.pem.PemReader
 import org.bouncycastle.util.io.pem.PemWriter
-import java.io.*
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.OutputStreamWriter
+import java.io.StringReader
+import java.io.StringWriter
 import java.security.KeyFactory
 import java.security.PrivateKey
 import java.security.interfaces.RSAPrivateKey
@@ -17,24 +23,26 @@ import java.security.spec.X509EncodedKeySpec
 class KeyConverter {
 
     fun toPem(rsaPrivateKey: RSAPrivateKey): String {
-        val privateKey = PemObject("PRIVATE KEY", rsaPrivateKey.encoded)
-
-        val outputStream = ByteArrayOutputStream()
-        try {
-            PemWriter(OutputStreamWriter(outputStream)).use { pemWriter -> pemWriter.writeObject(privateKey) }
-        } catch (e: IOException) {
-            throw IllegalStateException(e)
-        }
-
-        return String(outputStream.toByteArray())
+        return toPem(rsaPrivateKey.encoded, "PRIVATE KEY")
     }
 
     fun toPem(rsaPublicKey: RSAPublicKey): String {
-        val publicKey = PemObject("PUBLIC KEY", rsaPublicKey.encoded)
+        return toPem(rsaPublicKey.encoded, "PUBLIC KEY")
+    }
 
+    fun toPem(privateKeyInfo: PrivateKeyInfo): String {
+        return toPem(privateKeyInfo.encoded, "PRIVATE KEY")
+    }
+
+    fun toPem(encryptedPrivateKeyInfo: EncryptedPrivateKeyInfo): String {
+        return toPem(encryptedPrivateKeyInfo.encoded, "ENCRYPTED PRIVATE KEY")
+    }
+
+    private fun toPem(bytes: ByteArray, type: String): String {
+        val pem = PemObject(type, bytes)
         val outputStream = ByteArrayOutputStream()
         try {
-            PemWriter(OutputStreamWriter(outputStream)).use { pemWriter -> pemWriter.writeObject(publicKey) }
+            PemWriter(OutputStreamWriter(outputStream)).use { pemWriter -> pemWriter.writeObject(pem) }
         } catch (e: IOException) {
             throw IllegalStateException(e)
         }
@@ -50,10 +58,9 @@ class KeyConverter {
             val publicKeySpec = X509EncodedKeySpec(pemContent)
             val kf = KeyFactory.getInstance("RSA")
             return kf.generatePublic(publicKeySpec) as RSAPublicKey
-        } catch (e: Exception){
-            throw java.lang.IllegalStateException("Unable to convert public key ",e)
+        } catch (e: Exception) {
+            throw java.lang.IllegalStateException("Unable to convert public key ", e)
         }
-
     }
 
     fun toRSAPrivateKey(privateKeyString: String): RSAPrivateKey {
@@ -64,10 +71,9 @@ class KeyConverter {
             val privateKeySpec = PKCS8EncodedKeySpec(pemContent)
             val kf = KeyFactory.getInstance("RSA")
             return kf.generatePrivate(privateKeySpec) as RSAPrivateKey
-        } catch (e: Exception){
-            throw java.lang.IllegalStateException("Unable to convert private key ",e)
+        } catch (e: Exception) {
+            throw java.lang.IllegalStateException("Unable to convert private key ", e)
         }
-
     }
 
     /*
@@ -78,13 +84,12 @@ class KeyConverter {
         try {
             val pemParser = PEMParser(StringReader(privateKeyString))
             val converter = JcaPEMKeyConverter()
-            val `object` = pemParser.readObject()
-            val kp = converter.getKeyPair(`object` as PEMKeyPair)
+            val obj = pemParser.readObject()
+            val kp = converter.getKeyPair(obj as PEMKeyPair)
             return kp.private
         } catch (e: IOException) {
-            throw IllegalStateException("unable to convert PKCS1 to PCKC8",e)
+            throw IllegalStateException("unable to convert PKCS1 to PCKC8", e)
         }
-
     }
 
     fun convertPKCS8ToPEM(privateKeyPKCS8: ByteArray): String {
@@ -92,16 +97,15 @@ class KeyConverter {
             val pemObject = PemObject("PRIVATE KEY", privateKeyPKCS8)
             val stringWriter = StringWriter()
             PemWriter(stringWriter)
-                .use {
-                    it.writeObject(pemObject)
-                    it.close()
-                }
+                    .use {
+                        it.writeObject(pemObject)
+                        it.close()
+                    }
 
             return stringWriter.toString()
         } catch (e: IOException) {
             throw IllegalStateException("unable to convert PKCS8 To PEM", e)
         }
-
     }
 
     fun isFromPKCS1(keyPem: String): Boolean {


### PR DESCRIPTION
Making pems also from `PrivateKeyInfo` and `EncryptedPrivateKeyInfo`.

@m-awadi this is tested by encryption unit test in `EncryptedPrivateKeyExportEncryptorTest`, do you want to have separate tests here as well? The old `toPem()` methods were not tested here either.