### PR TITLE
[#BTTF-139] Android | Store data points in Android EncryptedSharedPreferences

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -11,13 +11,16 @@ ext {
     androidX = '1.1.0'
     rxAndroid = '2.1.1'
     assertJ = '3.14.0'
-
+    securityCrypto = '1.0.0-rc02'
 
     commonDependencies = [rxAndroid   : "io.reactivex.rxjava2:rxandroid:${rxAndroid}",
                           timber      : "com.jakewharton.timber:timber:${timber}",
                           rxJava2     : "io.reactivex.rxjava2:rxjava:${rxJava2}",
                           options     : "com.github.tomaszpolanski:options:${options}",
                           bouncyCastle: "org.bouncycastle:bcpkix-jdk15on:${bouncyCastle}",
+        androidx: [
+            securityCrypto: "androidx.security:security-crypto:${securityCrypto}"
+        ],
         google: [
             gson        : "com.google.code.gson:gson:${gson}",
             guava       : "com.google.guava:guava:$guava",

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,6 @@ org.gradle.jvmargs=-Xmx1536m
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
+android.enableJetifier=false
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official

--- a/vivy_encryptor/build.gradle
+++ b/vivy_encryptor/build.gradle
@@ -58,6 +58,8 @@ dependencies {
     api commonDependencies.google.guava
     api commonDependencies.bouncyCastle
     api commonDependencies.google.elepticCurve
+    api commonDependencies.androidx.securityCrypto
+
 
     testImplementation 'junit:junit:4.12'
     androidTestImplementation commonTestDependencies.testRunner

--- a/vivy_encryptor/src/androidTest/java/com/vivy/localEncryption/SymmetricEncryptedSharedPreferencesTest.kt
+++ b/vivy_encryptor/src/androidTest/java/com/vivy/localEncryption/SymmetricEncryptedSharedPreferencesTest.kt
@@ -1,0 +1,220 @@
+package com.vivy.localEncryption
+
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.gson.Gson
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class SymmetricEncryptedSharedPreferencesTest {
+
+    private lateinit var storage: SymmetricEncryptedSharedPreferences
+    private lateinit var encryptedSharedPreferences: EncryptedSharedPreferences
+
+    private val testEmail = "test@vivy.com"
+    private val gson = Gson()
+
+    private val userIdentifier: UserIdentifier by lazy {
+        object : UserIdentifier {
+            override fun getId(): String {
+                return "test@vivy.com"
+            }
+        }
+    }
+
+    @Before
+    fun setup() {
+        encryptedSharedPreferences = setupEncryptedSharedPreferences()
+        storage = SymmetricEncryptedSharedPreferences(encryptedSharedPreferences, userIdentifier, gson)
+    }
+
+    //update
+
+    @Test
+    fun updateKeyForCurrentUser() {
+        encryptedSharedPreferences.edit().clear()
+
+        val expectedResult = "This is a test for updating a key without explicitly specifying the user"
+        val key = "KEY_TEST_UPDATE_FOR_CURRENT_USER"
+
+        storage.update(key, expectedResult).blockingFirst()
+
+        val option = storage.get(key, testEmail).blockingGet()
+
+        Assert.assertTrue(option.isPresent)
+        Assert.assertEquals(expectedResult, option.get())
+    }
+
+    @Test
+    fun updateKeyForSpecificUser() {
+        encryptedSharedPreferences.edit().clear()
+
+        val expectedResult = "This is a test for updating a key for a user that was specified"
+        val key = "KEY_TEST_UPDATE_FOR_SPECIFIED_USER"
+        val specificTestEmail = "anna@vivy.com"
+
+        storage.update(key, expectedResult, specificTestEmail).blockingFirst()
+
+        val option = storage.get(key, specificTestEmail).blockingGet()
+        val optionCurrentUser = storage.get(key, testEmail).blockingGet()
+
+        Assert.assertTrue(option.isPresent)
+        Assert.assertTrue(!optionCurrentUser.isPresent)
+        Assert.assertEquals(expectedResult, option.get())
+    }
+
+    @Test
+    fun updateKeyForCurrentUserWithType() {
+        encryptedSharedPreferences.edit().clear()
+
+        val expectedResult = TestObject("This is a test for updating a key without explicitly specifying the user")
+        val key = "KEY_TEST_UPDATE_FOR_CURRENT_USER_WITH_TYPE"
+
+        storage.update(key, expectedResult).blockingFirst()
+
+        val option = storage.get(key, TestObject::class.java).blockingGet()
+
+        Assert.assertTrue(option.isSome)
+        Assert.assertEquals(expectedResult, option.orDefault { null })
+    }
+
+    @Test
+    fun updateKeyForSpecificUserWithType() {
+        encryptedSharedPreferences.edit().clear()
+
+        val expectedResult = TestObject("This is a test for updating a key for a specified user with type")
+        val key = "KEY_TEST_UPDATE_FOR_SPECIFIED_USER_WITH_TYPE"
+        val specificTestEmail = "anna@vivy.com"
+
+        storage.update(key, expectedResult, specificTestEmail).blockingFirst()
+
+        val option = storage.get(key, specificTestEmail).blockingGet()
+        val deserialisedResult = gson.fromJson(option.get(), TestObject::class.java)
+
+        Assert.assertTrue(option.isPresent)
+        Assert.assertEquals(expectedResult, deserialisedResult)
+    }
+
+    //delete
+
+    @Test
+    fun deleteKeyForCurrentUser() {
+        encryptedSharedPreferences.edit().clear()
+
+        val expectedResult = "This is a test for deleting a key without explicitly specifying the user"
+        val key = "KEY_TEST_DELETE_FOR_CURRENT_USER"
+
+        storage.update(key, expectedResult).blockingFirst()
+        storage.delete(key).blockingGet()
+
+        val option = storage.get(key, testEmail).blockingGet()
+
+        Assert.assertTrue(!option.isPresent)
+    }
+
+    @Test
+    fun deleteKeyForSpecifiedUser() {
+        encryptedSharedPreferences.edit().clear()
+
+        val expectedResult = "This is a test for deleting a key for a specified user"
+        val key = "KEY_TEST_DELETE_FOR_SPECIFIED_USER"
+        val specificTestEmail = "anna@vivy.com"
+
+        storage.update(key, expectedResult, specificTestEmail).blockingFirst()
+        storage.delete(key, specificTestEmail).blockingGet()
+
+        val option = storage.get(key, specificTestEmail).blockingGet()
+
+        Assert.assertTrue(!option.isPresent)
+    }
+
+    //isEntryAvailable
+
+    @Test
+    fun isEntryAvailableForCurrentUserForExistingKey() {
+        encryptedSharedPreferences.edit().clear()
+
+        val value = "This is a test for checking for a key for the current user"
+        val key = "KEY_TEST_EXISTING_KEY_FOR_CURRENT_USER"
+
+        storage.update(key, value).blockingFirst()
+
+        val result = storage.isEntryAvailable(key, testEmail).blockingGet()
+
+        Assert.assertEquals(result, true)
+    }
+
+    @Test
+    fun isEntryAvailableForCurrentUserForUnknownKey() {
+        encryptedSharedPreferences.edit().clear()
+
+        val key = "KEY_TEST_UNKNOWN_KEY_FOR_CURRENT_USER"
+
+        val result = storage.isEntryAvailable(key, testEmail).blockingGet()
+
+        Assert.assertEquals(result, false)
+    }
+
+    @Test
+    fun isEntryAvailableForSpecificUserForExistingKey() {
+        encryptedSharedPreferences.edit().clear()
+
+        val value = "This is a test for checking for a key for a specified user"
+        val key = "KEY_TEST_EXISTING_KEY_FOR_SPECIFIED_USER"
+        val specificTestEmail = "anna@vivy.com"
+
+        storage.update(key, value, specificTestEmail).blockingFirst()
+
+        val result = storage.isEntryAvailable(key, specificTestEmail).blockingGet()
+
+        Assert.assertEquals(result, true)
+    }
+
+    @Test
+    fun isEntryAvailableForSpecificUserForUnknownKey() {
+        encryptedSharedPreferences.edit().clear()
+
+        val key = "KEY_TEST_UNKNOWN_KEY_FOR_SPECIFIED_USER"
+        val specificTestEmail = "anna@vivy.com"
+
+        val result = storage.isEntryAvailable(key, specificTestEmail).blockingGet()
+
+        Assert.assertEquals(result, false)
+    }
+
+    //get
+
+    @Test
+    fun getKeyForCurrentUser() {
+        encryptedSharedPreferences.edit().clear()
+
+        val expectedResult = "This is a test for getting a key without explicitly specifying the user"
+        val key = "KEY_TEST_GET_FOR_CURRENT_USER"
+
+        storage.update(key, expectedResult).blockingFirst()
+
+        val option = storage.get(key).blockingGet()
+
+        Assert.assertTrue(option.isPresent)
+        Assert.assertEquals(expectedResult, option.get())
+    }
+
+    private fun setupEncryptedSharedPreferences(): EncryptedSharedPreferences {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+
+        return EncryptedSharedPreferences.create(
+            "TEST_STORAGE",
+            masterKeyAlias,
+            instrumentation.context,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        ) as EncryptedSharedPreferences
+    }
+
+    private data class TestObject(
+        val test: String
+    )
+}

--- a/vivy_encryptor/src/main/java/com/vivy/localEncryption/SymmetricEncryptedSharedPreferences.kt
+++ b/vivy_encryptor/src/main/java/com/vivy/localEncryption/SymmetricEncryptedSharedPreferences.kt
@@ -1,0 +1,84 @@
+package com.vivy.localEncryption
+
+import androidx.security.crypto.EncryptedSharedPreferences
+import com.google.common.base.Optional
+import com.google.gson.Gson
+import io.reactivex.Completable
+import io.reactivex.Observable
+import io.reactivex.Single
+import polanski.option.Option
+import com.vivy.localEncryption.EncryptedSharedPreferences as VivyEncryptedSharedPreferences
+
+class SymmetricEncryptedSharedPreferences(
+    private val storage: EncryptedSharedPreferences,
+    private val userIdentifier: UserIdentifier,
+    private val gson: Gson
+) : VivyEncryptedSharedPreferences {
+
+    override fun update(key: String, value: String): Observable<String> {
+        return update(key, value, userIdentifier.getId())
+    }
+
+    override fun <J> update(key: String, value: J): Observable<String> {
+        return update(key, value, userIdentifier.getId())
+    }
+
+    override fun delete(key: String): Completable {
+        return delete(key, userIdentifier.getId())
+    }
+
+    override fun get(key: String): Single<Optional<String>> {
+        return get(key, userIdentifier.getId())
+    }
+
+    override fun isEntryAvailable(key: String): Single<Boolean> {
+        return isEntryAvailable(key, userIdentifier.getId())
+    }
+
+
+    override fun update(key: String, value: String, user: String): Observable<String> {
+        return Observable.fromCallable {
+            storage.edit().putString(key + user, value).commit()
+        }.map { value }
+    }
+
+    override fun <J> update(key: String, value: J, user: String): Observable<String> {
+        return update(key, gson.toJson(value), user)
+    }
+
+    override fun delete(key: String, user: String): Completable {
+        return Completable.fromCallable {
+            storage.edit().remove(key + user).commit()
+        }
+    }
+
+    override fun get(key: String, user: String): Single<Optional<String>> {
+        return isEntryAvailable(key, user)
+            .map { available ->
+                if (!available) {
+                    Optional.absent()
+                } else {
+                    val value = storage.getString(key + user, "") ?: ""
+                    Optional.of(value)
+                }
+            }
+    }
+
+    override fun <J> get(key: String, clazz: Class<J>): Single<Option<J>> {
+        return get(key, userIdentifier.getId())
+            .map {
+                if (it.isPresent) {
+                    Option.ofObj(gson.fromJson(it.get(), clazz))
+                } else {
+                    Option.none()
+                }
+            }
+    }
+
+    override fun isEntryAvailable(key: String, user: String): Single<Boolean> {
+        return Single.fromCallable {
+            storage.contains(key + user)
+        }
+    }
+
+}


### PR DESCRIPTION
[BTTF-139](https://uvitadev.atlassian.net/secure/RapidBoard.jspa?rapidView=108&projectKey=BTTF&modal=detail&selectedIssue=BTTF-139)

Adding Android EncryptedSharedPreferences implementation