### PR TITLE
[#AN-518][code sharing] Refactor EncryptedSharedPreferences Interface

### DIFF
--- a/configurations.gradle
+++ b/configurations.gradle
@@ -1,6 +1,6 @@
 ext {
     android = [
-            minSdkVersion    : 23,
+            minSdkVersion    : 24,
             targetSdkVersion : 29,
             compileSdkVersion: 29
     ]

--- a/vivy_encryptor/src/main/java/com/vivy/localEncryption/EncryptedSharedPreferences.kt
+++ b/vivy_encryptor/src/main/java/com/vivy/localEncryption/EncryptedSharedPreferences.kt
@@ -4,7 +4,6 @@ import io.reactivex.Completable
 import io.reactivex.Maybe
 import io.reactivex.Observable
 import io.reactivex.Single
-import java.util.Optional
 
 interface EncryptedSharedPreferences {
 
@@ -45,14 +44,14 @@ interface EncryptedSharedPreferences {
     //endregion delete
 
     //region get deprecated
-    @Deprecated("use @getMaybe or @getOptional instead", ReplaceWith("getMaybe(key)"))
+    @Deprecated("use @getMaybe instead", ReplaceWith("getMaybe(key)"))
     fun get(
         key: String
     ): Single<com.google.common.base.Optional<String>> {
         return Single.just(com.google.common.base.Optional.absent())
     }
 
-    @Deprecated("use @getMaybe or @getOptional instead", ReplaceWith("getMaybe(key)"))
+    @Deprecated("use @getMaybe instead", ReplaceWith("getMaybe(key, user)"))
     fun get(
         key: String,
         user: String
@@ -60,7 +59,7 @@ interface EncryptedSharedPreferences {
         return Single.just(com.google.common.base.Optional.absent())
     }
 
-    @Deprecated("use @getMaybe or @getOptional instead", ReplaceWith("getMaybe(key)"))
+    @Deprecated("use @getMaybe instead", ReplaceWith("getMaybe(key, clazz)"))
     fun <J> get(
         key: String,
         clazz: Class<J>
@@ -98,36 +97,6 @@ interface EncryptedSharedPreferences {
         return Maybe.empty()
     }
     //endregion getMaybe
-
-    //region getOptional
-    fun getOptional(
-        key: String
-    ): Single<Optional<String>> {
-        return Single.just(Optional.empty())
-    }
-
-    fun getOptional(
-        key: String,
-        user: String
-    ): Single<Optional<String>> {
-        return Single.just(Optional.empty())
-    }
-
-    fun <J> getOptional(
-        key: String,
-        clazz: Class<J>
-    ): Single<Optional<J>> {
-        return Single.just(Optional.empty())
-    }
-
-    fun <J> getOptional(
-        key: String,
-        user: String,
-        clazz: Class<J>
-    ): Single<Optional<J>> {
-        return Single.just(Optional.empty())
-    }
-    //endregion getOptional
 
     //region available
     fun isEntryAvailable(

--- a/vivy_encryptor/src/main/java/com/vivy/localEncryption/EncryptedSharedPreferences.kt
+++ b/vivy_encryptor/src/main/java/com/vivy/localEncryption/EncryptedSharedPreferences.kt
@@ -1,65 +1,143 @@
 package com.vivy.localEncryption
 
-import com.google.common.base.Optional
 import io.reactivex.Completable
+import io.reactivex.Maybe
 import io.reactivex.Observable
 import io.reactivex.Single
-import polanski.option.Option
+import java.util.Optional
 
 interface EncryptedSharedPreferences {
+
+    //region update
     fun update(
-            key: String,
-            value: String,
-            user: String
+        key: String,
+        value: String
     ): Observable<String>
 
     fun update(
-            key: String,
-            value: String
+        key: String,
+        value: String,
+        user: String
     ): Observable<String>
 
     fun <J> update(
-            key: String,
-            value: J
+        key: String,
+        value: J
     ): Observable<String>
 
     fun <J> update(
-            key: String,
-            value: J,
-            user: String
+        key: String,
+        value: J,
+        user: String
     ): Observable<String>
 
+    //endregion update
+
+    //region delete
     fun delete(
-            key: String,
-            user: String
+        key: String
     ): Completable
 
     fun delete(
-            key: String
+        key: String,
+        user: String
     ): Completable
+    //endregion delete
 
+    //region get deprecated
+    @Deprecated("use @getMaybe or @getOptional instead", ReplaceWith("getMaybe(key)"))
     fun get(
-            key: String,
-            user: String
-    ): Single<Optional<String>>
+        key: String
+    ): Single<com.google.common.base.Optional<String>> {
+        return Single.just(com.google.common.base.Optional.absent())
+    }
 
+    @Deprecated("use @getMaybe or @getOptional instead", ReplaceWith("getMaybe(key)"))
     fun get(
-            key: String
-    ): Single<Optional<String>>
+        key: String,
+        user: String
+    ): Single<com.google.common.base.Optional<String>> {
+        return Single.just(com.google.common.base.Optional.absent())
+    }
 
-
+    @Deprecated("use @getMaybe or @getOptional instead", ReplaceWith("getMaybe(key)"))
     fun <J> get(
-            key: String,
-            clazz: Class<J>
-    ): Single<Option<J>>
+        key: String,
+        clazz: Class<J>
+    ): Single<polanski.option.Option<J>> {
+        return Single.just(polanski.option.Option.none())
+    }
+    //endregion get
 
+    //region getMaybe
+    fun getMaybe(
+        key: String
+    ): Maybe<String> {
+        return Maybe.empty()
+    }
 
+    fun getMaybe(
+        key: String,
+        user: String
+    ): Maybe<String> {
+        return Maybe.empty()
+    }
+
+    fun <J> getMaybe(
+        key: String,
+        clazz: Class<J>
+    ): Maybe<J> {
+        return Maybe.empty()
+    }
+
+    fun <J> getMaybe(
+        key: String,
+        user: String,
+        clazz: Class<J>
+    ): Maybe<J> {
+        return Maybe.empty()
+    }
+    //endregion getMaybe
+
+    //region getOptional
+    fun getOptional(
+        key: String
+    ): Single<Optional<String>> {
+        return Single.just(Optional.empty())
+    }
+
+    fun getOptional(
+        key: String,
+        user: String
+    ): Single<Optional<String>> {
+        return Single.just(Optional.empty())
+    }
+
+    fun <J> getOptional(
+        key: String,
+        clazz: Class<J>
+    ): Single<Optional<J>> {
+        return Single.just(Optional.empty())
+    }
+
+    fun <J> getOptional(
+        key: String,
+        user: String,
+        clazz: Class<J>
+    ): Single<Optional<J>> {
+        return Single.just(Optional.empty())
+    }
+    //endregion getOptional
+
+    //region available
     fun isEntryAvailable(
-            key: String,
-            user: String
+        key: String,
+        user: String
     ): Single<Boolean>
 
     fun isEntryAvailable(
-            key: String
+        key: String
     ): Single<Boolean>
+    //endregion available
+
 }

--- a/vivy_encryptor/src/main/java/com/vivy/localEncryption/SymmetricEncryptedSharedPreferences.kt
+++ b/vivy_encryptor/src/main/java/com/vivy/localEncryption/SymmetricEncryptedSharedPreferences.kt
@@ -6,7 +6,6 @@ import io.reactivex.Completable
 import io.reactivex.Maybe
 import io.reactivex.Observable
 import io.reactivex.Single
-import java.util.Optional
 import com.vivy.localEncryption.EncryptedSharedPreferences as VivyEncryptedSharedPreferences
 
 class SymmetricEncryptedSharedPreferences(
@@ -64,7 +63,7 @@ class SymmetricEncryptedSharedPreferences(
     }
     //endregion delete
 
-    //region get Maybe
+    //region getMaybe
     override fun getMaybe(
         key: String
     ): Maybe<String> {
@@ -104,51 +103,7 @@ class SymmetricEncryptedSharedPreferences(
                 value
             }
     }
-    //endregion get
-
-    override fun getOptional(
-        key: String
-    ): Single<Optional<String>> {
-        return getOptional(key, userIdentifier.getId())
-    }
-
-    override fun getOptional(
-        key: String,
-        user: String
-    ): Single<Optional<String>> {
-        return isEntryAvailable(key, user)
-            .map { available ->
-                if (!available) {
-                    Optional.empty()
-                } else {
-                    val value = storage.getString(key + user, "") ?: ""
-                    Optional.of(value)
-                }
-            }
-    }
-
-    override fun <J> getOptional(
-        key: String,
-        clazz: Class<J>
-    ): Single<Optional<J>> {
-        return getOptional(key, userIdentifier.getId(), clazz)
-    }
-
-    override fun <J> getOptional(
-        key: String,
-        user: String,
-        clazz: Class<J>
-    ): Single<Optional<J>> {
-        return getOptional(key, user)
-            .map { optionalValue ->
-                if (!optionalValue.isPresent) {
-                    Optional.empty()
-                } else {
-                    val value = gson.fromJson(optionalValue.get(), clazz)
-                    Optional.of(value)
-                }
-            }
-    }
+    //endregion getMaybe
 
     //region available
     override fun isEntryAvailable(

--- a/vivy_encryptor/src/main/java/com/vivy/localEncryption/SymmetricEncryptedSharedPreferences.kt
+++ b/vivy_encryptor/src/main/java/com/vivy/localEncryption/SymmetricEncryptedSharedPreferences.kt
@@ -1,63 +1,125 @@
 package com.vivy.localEncryption
 
 import androidx.security.crypto.EncryptedSharedPreferences
-import com.google.common.base.Optional
 import com.google.gson.Gson
 import io.reactivex.Completable
+import io.reactivex.Maybe
 import io.reactivex.Observable
 import io.reactivex.Single
-import polanski.option.Option
+import java.util.Optional
 import com.vivy.localEncryption.EncryptedSharedPreferences as VivyEncryptedSharedPreferences
 
-@Suppress("TooManyFunctions")
 class SymmetricEncryptedSharedPreferences(
     private val storage: EncryptedSharedPreferences,
     private val userIdentifier: UserIdentifier,
     private val gson: Gson
 ) : VivyEncryptedSharedPreferences {
 
-    override fun update(key: String, value: String): Observable<String> {
+    //region update
+    override fun update(
+        key: String,
+        value: String
+    ): Observable<String> {
         return update(key, value, userIdentifier.getId())
     }
 
-    override fun <J> update(key: String, value: J): Observable<String> {
-        return update(key, value, userIdentifier.getId())
-    }
-
-    override fun delete(key: String): Completable {
-        return delete(key, userIdentifier.getId())
-    }
-
-    override fun get(key: String): Single<Optional<String>> {
-        return get(key, userIdentifier.getId())
-    }
-
-    override fun isEntryAvailable(key: String): Single<Boolean> {
-        return isEntryAvailable(key, userIdentifier.getId())
-    }
-
-
-    override fun update(key: String, value: String, user: String): Observable<String> {
+    override fun update(
+        key: String,
+        value: String,
+        user: String
+    ): Observable<String> {
         return Observable.fromCallable {
             storage.edit().putString(key + user, value).commit()
         }.map { value }
     }
 
-    override fun <J> update(key: String, value: J, user: String): Observable<String> {
-        return update(key, gson.toJson(value), user)
+    override fun <J> update(
+        key: String,
+        value: J
+    ): Observable<String> {
+        return update(key, value, userIdentifier.getId())
     }
 
-    override fun delete(key: String, user: String): Completable {
+    override fun <J> update(
+        key: String,
+        value: J,
+        user: String
+    ): Observable<String> {
+        return update(key, gson.toJson(value), user)
+    }
+    //endregion update
+
+    //region delete
+    override fun delete(key: String): Completable {
+        return delete(key, userIdentifier.getId())
+    }
+
+    override fun delete(
+        key: String,
+        user: String
+    ): Completable {
         return Completable.fromCallable {
             storage.edit().remove(key + user).commit()
         }
     }
+    //endregion delete
 
-    override fun get(key: String, user: String): Single<Optional<String>> {
+    //region get Maybe
+    override fun getMaybe(
+        key: String
+    ): Maybe<String> {
+        return getMaybe(key, userIdentifier.getId())
+    }
+
+    override fun getMaybe(
+        key: String,
+        user: String
+    ): Maybe<String> {
+        return isEntryAvailable(key, user)
+            .flatMapMaybe { available ->
+                if (!available) {
+                    Maybe.empty()
+                } else {
+                    val value = storage.getString(key + user, "") ?: ""
+                    Maybe.just(value)
+                }
+            }
+    }
+
+    override fun <J> getMaybe(
+        key: String,
+        clazz: Class<J>
+    ): Maybe<J> {
+        return getMaybe(key, userIdentifier.getId(), clazz)
+    }
+
+    override fun <J> getMaybe(
+        key: String,
+        user: String,
+        clazz: Class<J>
+    ): Maybe<J> {
+        return getMaybe(key, user)
+            .map {
+                val value = gson.fromJson(it, clazz)
+                value
+            }
+    }
+    //endregion get
+
+    override fun getOptional(
+        key: String
+    ): Single<Optional<String>> {
+        return getOptional(key, userIdentifier.getId())
+    }
+
+    override fun getOptional(
+        key: String,
+        user: String
+    ): Single<Optional<String>> {
         return isEntryAvailable(key, user)
             .map { available ->
                 if (!available) {
-                    Optional.absent()
+                    Optional.empty()
                 } else {
                     val value = storage.getString(key + user, "") ?: ""
                     Optional.of(value)
@@ -65,21 +127,44 @@ class SymmetricEncryptedSharedPreferences(
             }
     }
 
-    override fun <J> get(key: String, clazz: Class<J>): Single<Option<J>> {
-        return get(key, userIdentifier.getId())
-            .map {
-                if (it.isPresent) {
-                    Option.ofObj(gson.fromJson(it.get(), clazz))
+    override fun <J> getOptional(
+        key: String,
+        clazz: Class<J>
+    ): Single<Optional<J>> {
+        return getOptional(key, userIdentifier.getId(), clazz)
+    }
+
+    override fun <J> getOptional(
+        key: String,
+        user: String,
+        clazz: Class<J>
+    ): Single<Optional<J>> {
+        return getOptional(key, user)
+            .map { optionalValue ->
+                if (!optionalValue.isPresent) {
+                    Optional.empty()
                 } else {
-                    Option.none()
+                    val value = gson.fromJson(optionalValue.get(), clazz)
+                    Optional.of(value)
                 }
             }
     }
 
-    override fun isEntryAvailable(key: String, user: String): Single<Boolean> {
+    //region available
+    override fun isEntryAvailable(
+        key: String
+    ): Single<Boolean> {
+        return isEntryAvailable(key, userIdentifier.getId())
+    }
+
+    override fun isEntryAvailable(
+        key: String,
+        user: String
+    ): Single<Boolean> {
         return Single.fromCallable {
             storage.contains(key + user)
         }
     }
+    //endregion available
 
 }


### PR DESCRIPTION
refactoring encrypted shared preferences to use maybe instead of Option and Optional

another pr in the vivy app will replace get usages of SymmetricEncryptedSharedPreferences with getMaybe